### PR TITLE
Fix misaligned homepage bullet list

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -8,7 +8,7 @@ bodyClass: page-home
   <div class="container">
     <div class="row justify-content-start">
       <div class="col-12 col-md-7 col-lg-6 order-2 order-md-1">
-        {{ content }}
+        <div class="content">{{ content }}</div>
         {% if site.homepage.show_call_box %}
           {% include call.html show_button=true %}
         {% endif %}


### PR DESCRIPTION
## Problem
The text on the homepage (https://wisl.earth) is misaligned: the intro bullet list (Consulting, Managed Services, …) has its disc markers pushed flush against the left edge, out of alignment with the paragraph text above it.

## Cause
`_layouts/home.html` rendered `{{ content }}` directly, **without** a `.content` wrapper. The global reset in `_sass/components/_type.scss` zeroes list spacing:

```scss
ul, ol { margin: 0; padding: 0;
  li { padding: 0; margin: 0; }
}
```

Every other layout (`page`, `service`, `contact`, `team`) wraps content in `<div class="content">`, whose `.content li { margin-left: 20px }` rule restores indentation. The home layout was the only one missing it.

## Fix
Wrap the home content in `<div class="content">` to match the other layouts. One-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)