### PR TITLE
Bump CI and Docker Ruby to 3.3 (fix Pages deploy)

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -15,7 +15,7 @@ jobs:
       - name: 💎 setup ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: '3.3'
 
       - name: 🔨 install dependencies & build site
         uses: limjh16/jekyll-action-ts@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7-alpine
+FROM ruby:3.3-alpine
 RUN apk add --no-cache build-base gcc bash cmake git
 RUN gem install bundler -v "~>1.0" 
 RUN gem install bundler jekyll


### PR DESCRIPTION
## Problem
The `Deploy GitHub Pages` workflow [failed](https://github.com/wisl-wisl/wisl-wisl.github.io/actions/runs/26720299271) on `source`:

```
public_suffix-7.0.5 requires ruby version >= 3.2, which is incompatible with the
current version, ruby 2.7.8p225
Gemfile.lock probably needs updating.
```

## Cause
Dependabot PR #9 bumped `addressable` 2.8.0 → 2.9.0, which widened its dependency to `public_suffix (>= 2.0.2, < 8.0)`. Resolution then pulled `public_suffix` **7.0.5** into `Gemfile.lock` — and that gem requires **Ruby ≥ 3.2**. The deploy workflow pinned **Ruby 2.7** (now EOL), so dependency install fails.

## Fix
- `.github/workflows/github-pages.yml`: `ruby-version: 2.7` → `'3.3'`
- `Dockerfile`: `ruby:2.7-alpine` → `ruby:3.3-alpine` (local-dev parity)

Jekyll 4.x supports modern Ruby, and this clears the Node 20 / Ruby EOL deprecation noise on the runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)