### PR TITLE
Fix broken nav, dead hamburger, empty strip, and blank link previews

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,10 +20,12 @@ footer:
   copyright_text: '© WISL 🌎'
 
 seo:
-  meta_og_title: "WISL"
+  meta_og_title: "WISL — West Information Services Limited"
   meta_og_type: "website"
   meta_og_url: "https://wisl.earth"
-  meta_og_description: ""
+  meta_og_image: "https://wisl.earth/images/features/blacktusk.jpg"
+  meta_og_description: "West Information Services Limited — IT consulting, managed services, Ubiquiti UniFi, Linux and open source, and emergency support in the West Chilcotin, British Columbia, Canada."
+  meta_twitter_card: "summary_large_image"
 
 collections:
   services:

--- a/_data/menus.yml
+++ b/_data/menus.yml
@@ -1,8 +1,13 @@
 main:
-    - name: ''
+  - name: "~/"
+    url: "/"
+    weight: 1
+  - name: "Contact"
+    url: "/contact/"
+    weight: 2
   # - name: "Blog"
   #   url: "/blog/"
-  #   weight: 2
+  #   weight: 3
 
 footer:
   - name: "~/"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,7 +20,7 @@
   <meta name="twitter:creator" content="{{ site.seo.meta_twitter_creator }}" />
 </head>
 <body class='page {{page.bodyClass}}'>
-  <!-- {% include main-menu-mobile.html %} -->
+  {% include main-menu-mobile.html %}
   <div id="wrapper" class="wrapper">
     {% include header.html headerClass='header-extra' %}
     {{content}}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -22,6 +22,7 @@ bodyClass: page-home
   </div>
 </div>
 
+{% if site.services.size > 0 %}
 <div class="strip">
   <div class="container pt-6 pb-6 pb-md-10">
     <div class="row justify-content-start">
@@ -40,3 +41,4 @@ bodyClass: page-home
     </div>
   </div>
 </div>
+{% endif %}


### PR DESCRIPTION
Four small, user-visible fixes (the quick wins from the site review).

### 1. Nav menu was a single empty broken link
`_data/menus.yml` `main` held `- name: ''`, rendering `<li><a href=""></a></li>` in the header on every page (a11y + SEO problem). Replaced with real links — `~/` and `Contact` — matching the footer menu.

### 2. Hamburger button did nothing on mobile (and threw a JS error)
`_layouts/default.html` had `{% include main-menu-mobile.html %}` commented out, but the hamburger button still rendered. `scripts.js` calls `#main-menu-mobile`'s `.classList.toggle()`, so tapping it hit a null reference. Re-enabled the include.

### 3. Empty padded strip under the homepage intro
`home.html` loops `site.services`, which is empty (`collections.services.output: false`, no `_services`, `features.json: []`), leaving a blank `.strip` block with `pt-6 pb-6 pb-md-10` padding. Guarded with `{% if site.services.size > 0 %}`.

### 4. Shared links had no preview
`og:image`, `og:description`, and `twitter:card` were blank in `_config.yml`. Set an OG image (`blacktusk.jpg`), a real description, and `summary_large_image`.

### Verification
Production `jekyll build` on `ruby:3.3` (matches CI): nav renders the two links, `#main-menu-mobile` is present, the empty strip is gone, and the og/twitter tags are populated. Screenshotted the built header to confirm the nav.

Remaining review items (sitemap/seo-tag, logo `alt`, image perf, stale CodeQL workflow, Dart Sass 2.0 deprecations) are left for follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)