### PR TITLE
SEO (seo-tag + sitemap + robots), logo alt fix, image/font perf

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source "https://rubygems.org"
 
 gem "jekyll", "~> 4.3"
 gem "jekyll-environment-variables"
+gem "jekyll-seo-tag"
+gem "jekyll-sitemap"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,10 @@ GEM
       jekyll (>= 3.0, < 5.x)
     jekyll-sass-converter (3.1.0)
       sass-embedded (~> 1.75)
+    jekyll-seo-tag (2.9.0)
+      jekyll (>= 3.8, < 5.0)
+    jekyll-sitemap (1.4.0)
+      jekyll (>= 3.7, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     json (2.19.7)
@@ -88,6 +92,8 @@ PLATFORMS
 DEPENDENCIES
   jekyll (~> 4.3)
   jekyll-environment-variables
+  jekyll-seo-tag
+  jekyll-sitemap
 
 BUNDLED WITH
   4.0.12

--- a/_config.yml
+++ b/_config.yml
@@ -7,25 +7,36 @@ exclude:
   - '*.yml'
   - '*.yaml'
 permalink: pretty
-title: ''
+url: "https://wisl.earth"
+title: "WISL"
+tagline: "West Information Services Limited"
+description: "West Information Services Limited — IT consulting, managed services, Ubiquiti UniFi networks, Linux and open source software, and emergency support in the West Chilcotin, British Columbia, Canada."
+logo: "/images/logo/wisl.svg"
+social:
+  name: "West Information Services Limited"
+  links:
+    - "https://github.com/wisl-wisl/wisl-wisl.github.io"
+
+plugins:
+  - jekyll-environment-variables
+  - jekyll-seo-tag
+  - jekyll-sitemap
+
+defaults:
+  - scope:
+      path: ""
+    values:
+      image: "/images/features/blacktusk.jpg"
 
 google_analytics_id: "G-06888T50J0"
 homepage:
   show_call_box: false
-logo:
+brand:
   mobile: "images/logo/wisl.svg"
   desktop: "images/logo/wisl.svg"
   desktop_height: "80px"
 footer:
   copyright_text: '© WISL 🌎'
-
-seo:
-  meta_og_title: "WISL — West Information Services Limited"
-  meta_og_type: "website"
-  meta_og_url: "https://wisl.earth"
-  meta_og_image: "https://wisl.earth/images/features/blacktusk.jpg"
-  meta_og_description: "West Information Services Limited — IT consulting, managed services, Ubiquiti UniFi, Linux and open source, and emergency support in the West Chilcotin, British Columbia, Canada."
-  meta_twitter_card: "summary_large_image"
 
 collections:
   services:

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,10 +1,10 @@
 <div class='header'>
   <div class="container">
     <div class="logo">
-      <a href="{{site.baseurl}}/"><img height="{{ site.logo.desktop_height }}" alt="{{ site.title }}" src="{{ site.logo.desktop | relative_url }}" /></a>
+      <a href="{{site.baseurl}}/"><img height="{{ site.brand.desktop_height }}" alt="WISL home" src="{{ site.brand.desktop | relative_url }}" /></a>
     </div>
     <div class="logo-mobile">
-      <a href="{{site.baseurl}}/"><img alt="{{ site.title }}" src="{{ site.logo.mobile | relative_url }}" /></a>
+      <a href="{{site.baseurl}}/"><img alt="WISL home" src="{{ site.brand.mobile | relative_url }}" /></a>
     </div>
     {% include main-menu.html %}
     {% include hamburger.html %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,22 +2,13 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>{% if page.title %}{{page.title}}{% else %}{{ site.title | escape }}{% endif %}</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="icon" type="image/svg" href="{{ '/images/logo/favicon.svg' | relative_url }}">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&display=swap" rel="stylesheet">
   <link href="{{ '/assets/css/style.css' | relative_url }}" rel="stylesheet">
-  {% if page.description %}
-  <meta name="description" content="{{ page.description }}" />
-  {% endif %}
-  <meta property="og:title" content="{{ site.seo.meta_og_title }}" />
-  <meta property="og:type" content="{{ site.seo.meta_og_type }}" />
-  <meta property="og:url" content="{{ site.seo.meta_og_url }}" />
-  <meta property="og:image" content="{{ site.seo.meta_og_image }}" />
-  <meta property="og:description" content="{{ site.seo.meta_og_description }}" />
-  <meta name="twitter:card" content="{{ site.seo.meta_twitter_card }}" />
-  <meta name="twitter:site" content="{{ site.seo.meta_twitter_site }}" />
-  <meta name="twitter:creator" content="{{ site.seo.meta_twitter_creator }}" />
+  {% seo %}
 </head>
 <body class='page {{page.bodyClass}}'>
   {% include main-menu-mobile.html %}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -15,7 +15,7 @@ bodyClass: page-home
       </div>
       {% if page.intro_image %}
       <div class="col-12 col-md-5 col-lg-6 order-1 order-md-2 position-relative">
-        <img alt={{ page.title }} class="intro-image{% if page.intro_image_absolute %} intro-image-absolute{% endif %}{% if page.intro_image_hide_on_mobile %} intro-image-hide-mobile{% endif %}" src="{{ page.intro_image | relURL }}" />
+        <img alt="{{ page.title }}" width="800" height="532" decoding="async" fetchpriority="high" class="intro-image{% if page.intro_image_absolute %} intro-image-absolute{% endif %}{% if page.intro_image_hide_on_mobile %} intro-image-hide-mobile{% endif %}" src="{{ page.intro_image | relURL }}" />
       </div>
       {% endif %}
     </div>

--- a/index.md
+++ b/index.md
@@ -1,7 +1,7 @@
 ---
 title: WISL
 layout: home
-description: West Information Services Limited
+description: "West Information Services Limited — IT consulting, managed services, Ubiquiti UniFi networks, Linux and open source software, and emergency support in the West Chilcotin, British Columbia, Canada."
 intro_image: "images/features/blacktusk.jpg"
 intro_image_absolute: true
 intro_image_hide_on_mobile: false

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,8 @@
+---
+permalink: /robots.txt
+sitemap: false
+---
+User-agent: *
+Allow: /
+
+Sitemap: {{ '/sitemap.xml' | absolute_url }}


### PR DESCRIPTION
Implements the SEO / accessibility / performance items from the site review. **Stacks on #13** — review after that merges (the diff will then show only this branch's changes).

## SEO
- Added **jekyll-seo-tag** and **jekyll-sitemap** (Gemfile + `plugins:`), plus a templated **`robots.txt`** pointing at the generated sitemap.
- Replaced the hand-rolled `<title>`/`og:`/`twitter:` block in `default.html` with `{% seo %}`, and populated the standard config keys. seo-tag now emits canonical, OpenGraph, a `summary_large_image` Twitter card, and `WebSite`/Organization JSON-LD.
- Site-wide default OG/Twitter image (`blacktusk.jpg`) via `defaults`; richer homepage description.
- Renamed the theme's `logo:` **hash** to `brand:` (and updated `header.html`) so `logo:` is free for the **string** seo-tag wants for the JSON-LD publisher logo — the two collided and crashed the build until separated.

## Accessibility
- Logo `alt` was empty (`site.title` was blank) → set `alt="WISL home"` on both logo images.

## Performance
- Hero image: added `width`/`height` + `decoding="async"` + `fetchpriority="high"` (kills layout shift, prioritizes the LCP image); also quoted its unquoted `alt`.
- `preconnect` to the Google Fonts origins.

Notes: `blacktusk.jpg` is already an 80 KB / 800×532 progressive JPEG, so no recompression. `dockerComposeUp.png` is already excluded from the build by the existing `docker*` rule (confirmed in the output).

## Verification
Production `jekyll build` on `ruby:3.3`: exactly one `<title>` (`WISL | West Information Services Limited`), absolute `og:image`, clean Twitter card (no bogus `@` handles), and `sitemap.xml` + `robots.txt` generated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)