### PR TITLE
Modernize CodeQL workflow, bump checkout, quiet Sass deprecations

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,23 +12,27 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
 
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript' ]
+        language: [ 'javascript-typescript' ]
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v3
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📂 setup
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: 💎 setup ruby
         uses: ruby/setup-ruby@v1

--- a/_config.yml
+++ b/_config.yml
@@ -45,6 +45,15 @@ collections:
     output: false
     
 sass:
-  indentWidth: 4
-  style: compact # possible values: nested expanded compact compressed
-  precision: 10
+  # dart-sass (jekyll-sass-converter 3.x) only supports expanded/compressed;
+  # the old libsass options (indentWidth/precision, style: compact) are ignored.
+  style: compressed
+  # Silence the deprecation warnings from the vendored Bootstrap 4 SCSS, which
+  # we don't maintain. quiet_deps covers warnings raised inside the imported
+  # files; silence_deprecations also covers the @import statements themselves
+  # (flagged in the root stylesheet). The real fix is a Bootstrap 5 upgrade.
+  quiet_deps: true
+  silence_deprecations:
+    - import
+    - global-builtin
+    - color-functions


### PR DESCRIPTION
The CI / build-hygiene items from the review. **Stacks on #14** (which stacks on #13) — review once those merge; the diff will then narrow to this branch.

## CI
- **CodeQL workflow was broken**: it used the *retired* `github/codeql-action@v1` (errors on every push/PR/schedule) and `actions/checkout@v2`. Bumped to `codeql-action@v3` + `checkout@v4`, switched language to `javascript-typescript`, and added the `permissions:` block v3 requires (`security-events: write`).
- **Deploy workflow**: `actions/checkout@v2` → `v4` (the other Node 20 deprecation the runner flagged). `limjh16/jekyll-action-ts@v2` has no newer major, so its Node 20 warning remains until the action updates.

## Sass
- `jekyll-sass-converter` 3.x uses **dart-sass**, which only supports `expanded`/`compressed`. The libsass-era options (`indentWidth`, `precision`, `style: compact`) were silently ignored. Switched to **`style: compressed`** — also minifies the published CSS (~75 KB, was unminified).
- Silenced the vendored **Bootstrap 4** deprecation warnings (`import`, `global-builtin`, `color-functions`) via `quiet_deps` + `silence_deprecations`, so the build log is clean again. These are third-party files we don't maintain; the genuine fix is a **Bootstrap 5 upgrade** (larger, breaking — worth its own effort). Note the `@import` removal is slated for **Dart Sass 3.0**, and our `sass-embedded` is pinned to 1.x by jekyll-sass-converter, so there's no imminent breakage.

## Verification
Production `jekyll build` on `ruby:3.3`: **warning-free** log, CSS compiles compressed, and the rendered site is visually unchanged (screenshotted — nav, hero, list, footer all intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)